### PR TITLE
Feat: Add endpoints to downloaded cloud videos and sort into subfolders based on date

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ Trigger a snapshot and get the URL of the saved image.
   { "url": "https://static.example.com/Front Door/last.jpg" }
   ```
 
-#### POST `/download-recent-clips`
+#### POST `/download-recent-clips` and `/download-recent-clips-and-sort`
 
-Download clips from all or specified cameras since the last run.
+Download clips from all or specified cameras since the last run. The `/download-recent-clips-and-sort` version sorts by year, month, and date using subholders. Additionally, the `path/to/media/latest` folder is updated with the most recent 20 videos.
 
 * **Payload** (optional)
 
@@ -153,7 +153,7 @@ Download clips from all or specified cameras since the last run.
 
 #### POST `/download-clips-since`
 
-Download clips from all or specified cameras since a given ISO timestamp.
+Download clips from all or specified cameras since a given ISO timestamp. The `/download-clips-since-and-sort` version sorts by year, month, and date using subholders. Additionally, the `path/to/media/latest` folder is updated with the most recent 20 videos.
 
 * **Payload**
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,17 @@
 import os
 from datetime import timedelta
 
-TIMEDELTA = timedelta(hours=int(os.getenv("TIMEDELTA", 6)))
-CREDFILE  = "./credentials.json"
-MEDIA_DIR = "./media"
-LAST_IMAGE_FILENAME = "last_snap.jpg"
+def get_env_int(key: str, default: int) -> int:
+    try:
+        return int(os.getenv(key, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+class Config:
+    CREDFILE = "./credentials.json"
+    MEDIA_DIR = "./media"
+    LAST_IMAGE_FILENAME = "last_snap.jpg"
+    TIMEDELTA = timedelta(hours=int(os.getenv("TIMEDELTA", 6)))
+    RECENTS_HOURS = get_env_int("RECENTS_HOURS", 0)
+    # Maximum number of videos to keep in 'latest' when RECENTS_HOURS == 0
+    RECENTS_TOTAL = get_env_int("RECENTS_TOTAL", 20)

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -1,6 +1,6 @@
 from flask import abort
 from datetime import datetime, timezone
-from .config import TIMEDELTA
+from .config import Config
 
 def get_since_iso() -> str:
     """
@@ -13,7 +13,7 @@ def get_since_iso() -> str:
         str: An ISO-formatted timestamp (e.g. "2025-07-01T12:34:56.789012+00:00").
     """
     now_utc = datetime.now(timezone.utc)
-    return (now_utc - TIMEDELTA).isoformat()
+    return (now_utc - Config.TIMEDELTA).isoformat()
 
 def normalize_camera_names(cams):
     """

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,8 +1,8 @@
 import asyncio
 from flask import Blueprint, request, jsonify, abort, url_for
 from .helpers import get_since_iso, normalize_camera_names
-from .blink_service import capture_image, download_clips, list_cameras
-from .config import LAST_IMAGE_FILENAME
+from .blink_service import capture_image, download_clips, download_clips_index_and_sort, list_cameras
+from .config import Config
 
 bp = Blueprint("api", __name__)
 
@@ -36,7 +36,7 @@ def snap_camera():
         asyncio.run(capture_image(data["camera_name"]))
     except Exception as e:
         abort(500, str(e))
-    url = url_for("static", filename=f"{data['camera_name']}/{LAST_IMAGE_FILENAME}", _external=True)
+    url = url_for("static", filename=f"{data['camera_name']}/{Config.LAST_IMAGE_FILENAME}", _external=True)
     return jsonify(url=url)
 
 @bp.route("/download-recent-clips", methods=["POST"])
@@ -57,6 +57,25 @@ def download_recent_clips():
     except Exception as e:
         abort(500, str(e))
 
+@bp.route("/download-recent-clips", methods=["POST"])
+def download_recent_clips_and_sort():
+    """
+    POST /download-recent-clips-and-sort
+    ----------------------
+    Download clips from all (or specified) cameras since the last run.
+    Sort into subfolders based on the timestamp and update the /latest folder.
+    Expects JSON: {"camera_name": "<name>|all"} (optional)
+    Returns JSON: {"since": "<ISO>", "downloaded_clips": [...]}
+    """
+    data = request.get_json() or {}
+    names = normalize_camera_names(data.get("camera_name","all"))
+    since_iso = get_since_iso()
+    try:
+        clips = asyncio.run(download_clips_index_and_sort(names, since_iso))
+        return jsonify(since=since_iso, downloaded_clips=clips)
+    except Exception as e:
+        abort(500, str(e))
+
 @bp.route("/download-clips-since", methods=["POST"])
 def download_clips_since():
     """
@@ -71,6 +90,25 @@ def download_clips_since():
     since_iso = data.get("since") or get_since_iso()
     try:
         clips = asyncio.run(download_clips(names, since_iso))
+        return jsonify(since=since_iso, downloaded_clips=clips)
+    except Exception as e:
+        abort(500, str(e))
+
+@bp.route("/download-clips-since-and-sort", methods=["POST"])
+def download_clips_since_and_sort():
+    """
+    POST /download-clips-since-and-sort
+    ----------------------
+    Download clips from all (or specified) cameras since a given timestamp.
+    Sort into subfolders based on the timestamp and update the /latest folder.
+    Expects JSON: {"camera_name": "<name>|all", "since": "<ISO>"} (since optional)
+    Returns JSON: {"since": "<ISO>", "downloaded_clips": [...]}
+    """
+    data = request.get_json() or {}
+    names = normalize_camera_names(data.get("camera_name","all"))
+    since_iso = data.get("since") or get_since_iso()
+    try:
+        clips = asyncio.run(download_clips_index_and_sort(names, since_iso))
         return jsonify(since=since_iso, downloaded_clips=clips)
     except Exception as e:
         abort(500, str(e))


### PR DESCRIPTION
**Summary**
- Add endpoints to downloaded cloud videos and sort into subfolders based on date
- Create `/latest` folder to store the most recent clips
- Create `/idx` folder to store placeholder files
- Create `Config` class to store future env variables